### PR TITLE
Add env.yaml and docs about post-run

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,10 @@
+name: seqerakit
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - conda-forge::python>=3.8
+  - conda-forge::pyyaml=6.0
+  - bioconda::tower-cli=0.9.0
+  - bioconda::seqerakit


### PR DESCRIPTION
- Adds environment.yaml for conda with required dependencies
- Docs about generating metadata and calling `extract_metadata.py` in a post-run script on Seqera Platform